### PR TITLE
trying out multiple JDK versions, allowing v8 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
+matrix:
+  allow_failures:
+    - jdk: oraclejdk8


### PR DESCRIPTION
Works as expected.  Tests pass on oraclejdk7, openjdk7.  Tests fail (for now) on oraclejdk8.  But the build overall succeeds.