### PR TITLE
[#35] Replaced JSONValue formatter with Gson in Planout4jConfigShipperImpl

### DIFF
--- a/config/src/main/java/com/glassdoor/planout4j/config/Planout4jConfigShipperImpl.java
+++ b/config/src/main/java/com/glassdoor/planout4j/config/Planout4jConfigShipperImpl.java
@@ -43,7 +43,7 @@ public class Planout4jConfigShipperImpl implements Planout4jConfigShipper {
          targetBackend.persist(Maps.transformValues(compiledNamespace2Config, new Function<NamespaceConfig, String>() {
             @Override
             public String apply(final NamespaceConfig input) {
-               return JSONValue.toJSONString(input.getConfig());
+               return new JsonConfigFormatterImpl().format(input.getConfig());
             }
          }));
       }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,4 +15,10 @@
     <name>planout4j core</name>
     <description>PlanOut for Java core infrastructure (mostly ported from original PlanOut)</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/core/src/main/java/com/glassdoor/planout4j/config/ConfigFormatter.java
+++ b/core/src/main/java/com/glassdoor/planout4j/config/ConfigFormatter.java
@@ -1,0 +1,12 @@
+package com.glassdoor.planout4j.config;
+
+import java.util.Map;
+
+/**
+ * Formats a config as a string.
+ */
+public interface ConfigFormatter {
+
+    String format(Map<String, ?> config);
+
+}

--- a/core/src/main/java/com/glassdoor/planout4j/config/JsonConfigFormatterImpl.java
+++ b/core/src/main/java/com/glassdoor/planout4j/config/JsonConfigFormatterImpl.java
@@ -1,0 +1,34 @@
+package com.glassdoor.planout4j.config;
+
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Formats a config as a json string.
+ */
+public class JsonConfigFormatterImpl implements ConfigFormatter {
+
+    private final boolean pretty;
+
+    public JsonConfigFormatterImpl() {
+        this(false);
+    }
+
+    public JsonConfigFormatterImpl(final boolean pretty) {
+        this.pretty = pretty;
+    }
+
+    public String format(final Map<String, ?> config) {
+        return getGson(pretty).toJson(config);
+    }
+
+    private static Gson getGson(final boolean pretty) {
+        final GsonBuilder builder = new GsonBuilder();
+        if (pretty) {
+            builder.setPrettyPrinting();
+        }
+        return builder.create();
+    }
+}

--- a/tools/src/main/java/com/glassdoor/planout4j/tools/CompileTool.java
+++ b/tools/src/main/java/com/glassdoor/planout4j/tools/CompileTool.java
@@ -1,6 +1,7 @@
 package com.glassdoor.planout4j.tools;
 
 import java.io.*;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,13 +46,15 @@ public class CompileTool {
             file = null;
         }
         final String output = parsedArgs.getString("output");
+
         LOG.debug("Output goes to {}", output != null ? new File(output).getAbsolutePath() : "<STDOUT>");
         final Reader reader = file != null ? new FileReader(file) : new StringReader(input);
         final String namespace = yaml ? com.google.common.io.Files.getNameWithoutExtension(input) : null;
         try (final Writer writer = output != null ? new FileWriter(output) : new OutputStreamWriter(System.out)) {
-            writer.write(Planout4jTool.getGson(parsedArgs).toJson(yaml ?
+            final Map<String, ?> config = yaml ?
                     new YAMLConfigParser().parseAndValidate(reader, namespace).getConfig() :
-                    PlanoutDSLCompiler.dsl_to_json(CharStreams.toString(reader))));
+                    PlanoutDSLCompiler.dsl_to_json(CharStreams.toString(reader));
+            writer.write(Planout4jTool.getConfigFormatter(parsedArgs).format(config));
         }
     }
 

--- a/tools/src/main/java/com/glassdoor/planout4j/tools/NslistTool.java
+++ b/tools/src/main/java/com/glassdoor/planout4j/tools/NslistTool.java
@@ -17,9 +17,9 @@ import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
-import com.google.gson.Gson;
 
 import com.glassdoor.planout4j.NamespaceConfig;
+import com.glassdoor.planout4j.config.ConfigFormatter;
 import com.glassdoor.planout4j.config.Planout4jRepositoryImpl;
 import com.glassdoor.planout4j.config.ValidationException;
 
@@ -51,7 +51,7 @@ public class NslistTool {
         final DisplayMode mode = parsedArgs.get("mode");
         final Table table = new Table(5, BorderStyle.CLASSIC, ShownBorders.ALL);
         addCells(table, "name", "total segs", "used segs", "definitions", "active experiments");
-        final Gson gson = Planout4jTool.getGson(parsedArgs);
+        final ConfigFormatter configFormatter = Planout4jTool.getConfigFormatter(parsedArgs);
 
         final String namePatternStr = StringUtils.lowerCase(parsedArgs.getString("name"));
         Pattern namePattern = null;
@@ -73,7 +73,7 @@ public class NslistTool {
                 switch (mode) {
                     case full:
                         System.out.printf("********************** START of %s *********************\n", name);
-                        System.out.println(gson.toJson(nsConf.getConfig()));
+                        System.out.println(configFormatter.format(nsConf.getConfig()));
                         System.out.printf("*********************** END of %s **********************\n", name);
                         break;
                     case summary:

--- a/tools/src/main/java/com/glassdoor/planout4j/tools/Planout4jTool.java
+++ b/tools/src/main/java/com/glassdoor/planout4j/tools/Planout4jTool.java
@@ -13,12 +13,17 @@ import org.apache.log4j.PatternLayout;
 import org.slf4j.LoggerFactory;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
-import net.sourceforge.argparse4j.inf.*;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparsers;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import com.glassdoor.planout4j.config.ConfFileLoader;
+import com.glassdoor.planout4j.config.ConfigFormatter;
+import com.glassdoor.planout4j.config.JsonConfigFormatterImpl;
 import com.glassdoor.planout4j.util.VersionLogger;
 
 import static java.lang.String.format;
@@ -114,6 +119,10 @@ public class Planout4jTool {
         return builder.create();
     }
 
+    static ConfigFormatter getConfigFormatter(final Namespace parsedArgs) {
+        final boolean pretty = parsedArgs.getBoolean("pretty") == Boolean.TRUE;
+        return new JsonConfigFormatterImpl(pretty);
+    }
 
     private static void setupLoggin(final String level) {
         Logger.getRootLogger().addAppender(new ConsoleAppender(


### PR DESCRIPTION
Replaced JSONValue formatter with Gson in Planout4jConfigShipperImpl. Modified tools to use a common implementation for formatting configs as json.