### PR TITLE
Extend planout interpreter for Java.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
+  - oraclejdk9
+  - openjdk8
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
   - openjdk8
 
 matrix:

--- a/core/src/main/java/com/glassdoor/planout4j/planout/ops/core/Exp.java
+++ b/core/src/main/java/com/glassdoor/planout4j/planout/ops/core/Exp.java
@@ -1,0 +1,19 @@
+package com.glassdoor.planout4j.planout.ops.core;
+
+import com.glassdoor.planout4j.planout.ops.base.PlanOutOpUnary;
+import com.glassdoor.planout4j.util.Helper;
+import java.util.Map;
+
+public class Exp extends PlanOutOpUnary<Number> {
+
+  public Exp(final Map<String, Object> args) {
+    super(args);
+  }
+
+  @Override
+  protected Number unaryExecute(final Object value) {
+    final Double val = getNumber(value, "value").doubleValue();
+    return Helper.wrapNumber(Math.exp(val), false);
+  }
+
+}

--- a/core/src/main/java/com/glassdoor/planout4j/planout/ops/core/Sqrt.java
+++ b/core/src/main/java/com/glassdoor/planout4j/planout/ops/core/Sqrt.java
@@ -1,0 +1,23 @@
+package com.glassdoor.planout4j.planout.ops.core;
+
+import com.glassdoor.planout4j.planout.ops.base.PlanOutOpUnary;
+import com.glassdoor.planout4j.util.Helper;
+import java.util.Map;
+
+public class Sqrt extends PlanOutOpUnary<Number> {
+
+  public Sqrt(final Map<String, Object> args) {
+    super(args);
+  }
+
+  @Override
+  protected Number unaryExecute(final Object value) throws IllegalArgumentException {
+    final Double val = getNumber(value, "value").doubleValue();
+    if (val < 0) {
+      throw new IllegalArgumentException();
+    } else {
+      return Helper.wrapNumber(Math.sqrt(val), false);
+    }
+  }
+
+}

--- a/core/src/main/java/com/glassdoor/planout4j/planout/ops/utils/Operators.java
+++ b/core/src/main/java/com/glassdoor/planout4j/planout/ops/utils/Operators.java
@@ -55,6 +55,8 @@ public class Operators {
                 .put("coalesce", Coalesce.class)
                 .put("product", Product.class)
                 .put("sum", Sum.class)
+                .put("exp", Exp.class)
+                .put("sqrt", Sqrt.class)
                 .put("randomFloat", RandomFloat.class)
                 .put("randomInteger", RandomInteger.class)
                 .put("bernoulliTrial", BernoulliTrial.class)

--- a/core/src/test/java/com/glassdoor/planout4j/planout/InterpreterTest.java
+++ b/core/src/test/java/com/glassdoor/planout4j/planout/InterpreterTest.java
@@ -15,6 +15,9 @@ public class InterpreterTest {
     private final Object compiled = JSONValue.parse("{\"op\":\"seq\",\"seq\":[{\"op\":\"set\",\"var\":\"group_size\",\"value\":{\"choices\":{\"op\":\"array\",\"values\":[1,10]},\"unit\":{\"op\":\"get\",\"var\":\"userid\"},\"op\":\"uniformChoice\"}},{\"op\":\"set\",\"var\":\"specific_goal\",\"value\":{\"p\":0.8,\"unit\":{\"op\":\"get\",\"var\":\"userid\"},\"op\":\"bernoulliTrial\"}},{\"op\":\"cond\",\"cond\":[{\"if\":{\"op\":\"get\",\"var\":\"specific_goal\"},\"then\":{\"op\":\"seq\",\"seq\":[{\"op\":\"set\",\"var\":\"ratings_per_user_goal\",\"value\":{\"choices\":{\"op\":\"array\",\"values\":[8,16,32,64]},\"unit\":{\"op\":\"get\",\"var\":\"userid\"},\"op\":\"uniformChoice\"}},{\"op\":\"set\",\"var\":\"ratings_goal\",\"value\":{\"op\":\"product\",\"values\":[{\"op\":\"get\",\"var\":\"group_size\"},{\"op\":\"get\",\"var\":\"ratings_per_user_goal\"}]}}]}}]}]}");
     private final String interpreterSalt = "foo";
     private final Map<String, Object> inputs = Helper.cast(ImmutableMap.of("userid", 123454));
+    private final Object extendedInterpreterCompiledScript = JSONValue.parse("{\"op\":\"seq\",\"seq\":[{\"op\":\"cond\",\"cond\":[{\"if\":{\"p\":0.2,\"unit\":{\"op\":\"get\",\"var\":\"userid\"},\"salt\":\"salty\",\"op\":\"bernoulliTrial\"},\"then\":{\"op\":\"seq\",\"seq\":[{\"op\":\"set\",\"var\":\"explore\",\"value\":true},{\"op\":\"set\",\"var\":\"variant\",\"value\":{\"choices\":{\"op\":\"array\",\"values\":[\"arm1\",\"arm2\",\"arm3\"]},\"unit\":{\"op\":\"get\",\"var\":\"userid\"},\"op\":\"uniformChoice\"}}]}},{\"if\":true,\"then\":{\"op\":\"seq\",\"seq\":[{\"op\":\"set\",\"var\":\"score1\",\"value\":{\"value\":{\"values\":[0,{\"op\":\"sum\",\"values\":[{\"op\":\"sum\",\"values\":[12.123,{\"op\":\"product\",\"values\":[-2.1232,{\"op\":\"get\",\"var\":\"feature_1\"}]}]},{\"op\":\"product\",\"values\":[33.122,{\"op\":\"get\",\"var\":\"feature_2\"}]}]}],\"op\":\"max\"},\"op\":\"exp\"}},{\"op\":\"set\",\"var\":\"score2\",\"value\":{\"value\":{\"values\":[0,{\"op\":\"sum\",\"values\":[{\"op\":\"sum\",\"values\":[0.1111,{\"op\":\"product\",\"values\":[0.2222,{\"op\":\"get\",\"var\":\"feature_1\"}]}]},{\"op\":\"product\",\"values\":[0.3333,{\"op\":\"get\",\"var\":\"feature_2\"}]}]}],\"op\":\"max\"},\"op\":\"exp\"}},{\"op\":\"set\",\"var\":\"score3\",\"value\":{\"value\":{\"values\":[0,{\"op\":\"sum\",\"values\":[{\"op\":\"sum\",\"values\":[1,{\"op\":\"product\",\"values\":[5,{\"op\":\"get\",\"var\":\"feature_1\"}]}]},{\"op\":\"product\",\"values\":[-0.6612,{\"op\":\"get\",\"var\":\"feature_2\"}]}]}],\"op\":\"max\"},\"op\":\"exp\"}},{\"op\":\"set\",\"var\":\"explore\",\"value\":false},{\"op\":\"set\",\"var\":\"variant\",\"value\":{\"choices\":{\"op\":\"array\",\"values\":[\"arm1\",\"arm2\",\"arm3\"]},\"weights\":{\"op\":\"array\",\"values\":[{\"op\":\"get\",\"var\":\"score1\"},{\"op\":\"get\",\"var\":\"score2\"},{\"op\":\"get\",\"var\":\"score3\"}]},\"unit\":{\"op\":\"get\",\"var\":\"userid\"},\"op\":\"weightedChoice\"}}]}}]}]}");
+    private final Map<String, Object> extendedInterpreterInputs = Helper.cast(ImmutableMap.of("feature_1", 1, "feature_2", 0, "userid", 42));
+
 
     @Test
     public void testInterpreter() {
@@ -36,6 +39,17 @@ public class InterpreterTest {
         overrides = Helper.cast(ImmutableMap.of("userid", 123454));
         proc = new Interpreter(compiled, interpreterSalt, wrongInputs, overrides);
         assertEquals(true, proc.getParams().get("specific_goal"));
+    }
+
+    @Test
+    public void testExtendedInterpreter() {
+        Interpreter proc = new Interpreter(extendedInterpreterCompiledScript, "test_salt", extendedInterpreterInputs, null);
+        Map<String, Object> params = proc.getParams();
+        assertEquals(false, params.get("explore"));
+        assertEquals("arm1", params.get("variant"));
+        assertEquals(22022.060942147677, params.get("score1"));
+        assertEquals(1.3955659054472516, params.get("score2"));
+        assertEquals(403.4287934927351, params.get("score3"));
     }
 
 }

--- a/core/src/test/java/com/glassdoor/planout4j/planout/ops/CoreOpsTest.java
+++ b/core/src/test/java/com/glassdoor/planout4j/planout/ops/CoreOpsTest.java
@@ -272,6 +272,31 @@ public class CoreOpsTest {
         assertEquals(1l, round);
     }
 
+    @Test
+    public void testExp() {
+        Object exp =  runConfigSingle(new JSONObjectBuilder().p("op", "exp").p("value", 1));
+        assertEquals(2.718281828459045, exp);
+        exp = runConfigSingle(new JSONObjectBuilder().p("op", "exp").p("value", -0.5));
+        assertEquals(0.6065306597126334, exp);
+        exp = runConfigSingle(new JSONObjectBuilder().p("op", "exp").p("value", 0.123));
+        assertEquals(1.1308844209474893, exp);
+        exp = runConfigSingle(new JSONObjectBuilder().p("op", "exp").p("value", 1.88));
+        assertEquals(6.553504862191148, exp);
+    }
+
+    @Test
+    public void testSqrt() {
+        Object sqrt =  runConfigSingle(new JSONObjectBuilder().p("op", "sqrt").p("value", 1));
+        assertEquals(1.0, sqrt);
+        sqrt = runConfigSingle(new JSONObjectBuilder().p("op", "sqrt").p("value", 0.123));
+        assertEquals(0.3507135583350036, sqrt);
+        sqrt = runConfigSingle(new JSONObjectBuilder().p("op", "sqrt").p("value", 1.88));
+        assertEquals(1.3711309200802089, sqrt);
+        try {
+            sqrt = runConfigSingle(new JSONObjectBuilder().p("op", "sqrt").p("value", -0.5));
+        } catch (IllegalArgumentException e) {}
+    }
+
     private Interpreter returnRunner(Object value) {
         Object c = new JSONObjectBuilder().p("op", "seq").p("seq", new JSONArrayBuilder()
                         .a(new JSONObjectBuilder().p("op", "set").p("value", 2).p("var", "x"))


### PR DESCRIPTION
Extend planout interpreter for python to have sum and sqrt.
This is related to this issues:
1. [Extending the Interpreter to Use Sqrt and Exp Operator.](https://github.com/facebook/planout/issues/147)
2. [Example for online evaluation.](https://github.com/facebook/Ax/issues/77)

Related PR: https://github.com/facebook/planout/pull/148