### PR TITLE
Fixed @ CVE-2018-1275

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <json-simple.version>1.1.1</json-simple.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <typesafe-config.version>1.2.1</typesafe-config.version>
-        <spring.version>4.1.6.RELEASE</spring.version>
+        <spring.version>5.2.22.RELEASE</spring.version>
         <jedis.version>2.7.2</jedis.version>
         <argparse4j.version>0.5.0</argparse4j.version>
         <text-table.version>1.0</text-table.version>


### PR DESCRIPTION
## Vulnerability Description
Spring Framework, versions 5.0 prior to 5.0.5 and versions 4.3 prior to 4.3.16 and older unsupported versions, allow applications to expose STOMP over WebSocket endpoints with a simple, in-memory STOMP broker through the spring-messaging module. A malicious user (or attacker) can craft a message to the broker that can lead to a remote code execution attack. This CVE addresses the partial fix for https://github.com/advisories/GHSA-p5hg-3xm3-gcjg in the 4.3.x branch of the Spring Framework.

**CVE-2018-1275**
`CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
GHSA-3rmv-2pg5-xvqj
